### PR TITLE
Feature: Parsing Functions Literals

### DIFF
--- a/MonkeyInterpreter.AST/FunctionLiteral.cs
+++ b/MonkeyInterpreter.AST/FunctionLiteral.cs
@@ -1,0 +1,40 @@
+﻿using System.Text;
+using MonkeyInterpreter.Core;
+
+namespace MonkeyInterpreter.AST;
+
+public class FunctionLiteral : IExpression
+{
+    public Token Token;
+    public List<Identifier>? Parameters = new();
+    public BlockStatement? Body;
+
+    public FunctionLiteral(Token token)
+    {
+        Token = token;
+    }
+
+    public string TokenLiteral()
+    {
+        return Token.Literal;
+    }
+
+    public string String()
+    {
+        StringBuilder stringBuilder = new();
+        List<string> parameters = new();
+            
+        foreach(Identifier parameter in Parameters)
+        {
+            parameters.Add(parameter.String());
+        }
+
+        stringBuilder.Append(TokenLiteral());
+        stringBuilder.Append('(');
+        stringBuilder.Append(string.Join(", ", parameters));
+        stringBuilder.Append(") ");
+        stringBuilder.Append(Body?.String());
+
+        return stringBuilder.ToString();
+    }
+}

--- a/MonkeyInterpreter.Tests/Parser/ParserTest.cs
+++ b/MonkeyInterpreter.Tests/Parser/ParserTest.cs
@@ -647,6 +647,109 @@ public class IfExpressionTests
 		ExpressionStatement alternativeStatement = (ExpressionStatement)ifExpression.Alternative!.Statements[0];
 		
 		Assert.Equal(expectedAlernativeStatement, alternativeStatement.TokenLiteral());
+	}
+}
+
+public class FunctionLiteralTests
+{
+	[Theory]
+	[InlineData("fn(x, y) { x + y; }", 1)]
+	public void FunctionLiteral_ReturnsExpectedStatementCount(string expression, int expectedStatementCount)
+	{	
+		Core.Lexer lexer = new(expression);
+		AST.Parser parser = new(lexer);
+		AbstractSyntaxTree ast = parser.ParseProgram();
 		
+		Assert.Equal(expectedStatementCount, ast.Statements.Count);
+	}
+	
+	[Theory]
+	[InlineData("fn(x, y) { x + y; }")]
+	public void FunctionLiteral_StatementIsExpressionStatement(string expression)
+	{	
+		Core.Lexer lexer = new(expression);
+		AST.Parser parser = new(lexer);
+		AbstractSyntaxTree ast = parser.ParseProgram();
+		
+		Assert.IsType<ExpressionStatement>(ast.Statements[0]);
+	}
+	
+	[Theory]
+	[InlineData("fn(x, y) { x + y; }")]
+	public void FunctionLiteral_ExpressionIsFunctionLiteral(string expression)
+	{	
+		Core.Lexer lexer = new(expression);
+		AST.Parser parser = new(lexer);
+		AbstractSyntaxTree ast = parser.ParseProgram();
+
+		ExpressionStatement expressionStatement = (ExpressionStatement)ast.Statements[0];
+		
+		Assert.IsType<FunctionLiteral>(expressionStatement.Expression);
+	}
+	
+	[Theory]
+	[InlineData("fn(x, y) { x + y; }", 2)]
+	public void FunctionLiteral_ReturnsCorrectParamCount(string expression, int expectedParamCount)
+	{	
+		Core.Lexer lexer = new(expression);
+		AST.Parser parser = new(lexer);
+		AbstractSyntaxTree ast = parser.ParseProgram();
+
+		ExpressionStatement expressionStatement = (ExpressionStatement)ast.Statements[0];
+		FunctionLiteral functionLiteral = (FunctionLiteral)expressionStatement.Expression;
+		
+		Assert.Equal(expectedParamCount, functionLiteral.Parameters.Count);
+	}
+	
+	[Theory]
+	[InlineData("fn(x, y) { x + y; }", 1)]
+	public void FunctionLiteral_BodyStatementIsExpressionStatement(string expression, int expectedStatementCount)
+	{	
+		Core.Lexer lexer = new(expression);
+		AST.Parser parser = new(lexer);
+		AbstractSyntaxTree ast = parser.ParseProgram();
+
+		ExpressionStatement expressionStatement = (ExpressionStatement)ast.Statements[0];
+		FunctionLiteral functionLiteral = (FunctionLiteral)expressionStatement.Expression;
+		ExpressionStatement bodyStatement = (ExpressionStatement)functionLiteral.Body.Statements[0];
+		
+		Assert.IsType<ExpressionStatement>(functionLiteral.Body.Statements[0]);
+		
+		
+	}
+
+	[Theory]
+	[InlineData("fn(x, y) { x + y; }", "(x+y)")]
+	public void FunctionLiteral_ReturnsExpectedBodyExpression(string expression, string expectedParsedStatement)
+	{
+		Core.Lexer lexer = new(expression);
+		AST.Parser parser = new(lexer);
+		AbstractSyntaxTree ast = parser.ParseProgram();
+
+		ExpressionStatement expressionStatement = (ExpressionStatement)ast.Statements[0];
+		FunctionLiteral functionLiteral = (FunctionLiteral)expressionStatement.Expression;
+		ExpressionStatement bodyStatement = (ExpressionStatement)functionLiteral.Body!.Statements[0];
+	
+		Assert.Equal(expectedParsedStatement, bodyStatement.String());
+	}
+	
+	[Theory]
+	[InlineData("fn(x, y) { x + y; }", new[] {"x", "y"})]
+	public void FunctionLiteral_ReturnsExpectedParameters(string expression, string[] expectedParsedStatement)
+	{
+		Core.Lexer lexer = new(expression);
+		AST.Parser parser = new(lexer);
+		AbstractSyntaxTree ast = parser.ParseProgram();
+
+		ExpressionStatement expressionStatement = (ExpressionStatement)ast.Statements[0];
+		FunctionLiteral functionLiteral = (FunctionLiteral)expressionStatement.Expression;
+
+		List<string> parameters = new();
+		foreach (Identifier identifier in functionLiteral.Parameters)
+		{
+			parameters.Add(identifier.Value);
+		}
+		
+		Assert.Equal(expectedParsedStatement, parameters.ToArray());
 	}
 }


### PR DESCRIPTION
## Added `FunctionLiteral` parsing classes and methods

- Created `FunctionLiteral` class
- Added `Parser.ParseFunctionLiteral` method
- Added `Parser.ParseFunctionParameters` method

## Added tests for `FunctionLiteral` parsing

- Usual tests plus tests for function parameters and body statements