### PR TITLE
Feature: Completing Baseline Parser

### DIFF
--- a/MonkeyInterpreter.AST/CallExpression.cs
+++ b/MonkeyInterpreter.AST/CallExpression.cs
@@ -1,0 +1,42 @@
+﻿using System.Text;
+using MonkeyInterpreter.Core;
+
+namespace MonkeyInterpreter.AST;
+
+public class CallExpression : IExpression
+{
+	public Token Token;
+	public IExpression Function;
+	public List<IExpression>? Arguments;
+
+	public CallExpression(Token token, IExpression function, List<IExpression> arguments)
+	{
+		Token = token;
+		Function = function;
+		Arguments = arguments;
+	}
+
+	public string TokenLiteral()
+	{
+		return Token.Literal;
+	}
+
+	public string String()
+	{
+		StringBuilder stringBuilder = new();
+
+		List<string> arguments = new();
+
+		foreach (IExpression argument in Arguments)
+		{
+			arguments.Add(argument.String());
+		}
+
+		stringBuilder.Append(Function.String());
+		stringBuilder.Append('(');
+		stringBuilder.Append(string.Join(", ", arguments));
+		stringBuilder.Append(')');
+
+		return stringBuilder.ToString();
+	}
+}

--- a/MonkeyInterpreter.REPL/MonkeyInterpreter.REPL.csproj
+++ b/MonkeyInterpreter.REPL/MonkeyInterpreter.REPL.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\MonkeyInterpreter.AST\MonkeyInterpreter.AST.csproj" />
       <ProjectReference Include="..\MonkeyInterpreter.Core\MonkeyInterpreter.Core.csproj" />
     </ItemGroup>
 

--- a/MonkeyInterpreter.REPL/Repl.cs
+++ b/MonkeyInterpreter.REPL/Repl.cs
@@ -1,4 +1,5 @@
-﻿using MonkeyInterpreter.Core;
+﻿using MonkeyInterpreter.AST;
+using MonkeyInterpreter.Core;
 
 namespace MonkeyInterpreter.REPL;
 
@@ -13,23 +14,33 @@ public static class Repl
 			writer.Write(Prompt);
 			string? line = reader.ReadLine();
 
-			Console.WriteLine($"'{line}'");
-			
 			if (line is null)
 			{
 				return;
 			}
 			
-			Lexer lexer = new Lexer(line!);
+			Lexer lexer = new(line!);
+			Parser parser = new(lexer);
+			AbstractSyntaxTree ast = parser.ParseProgram();
 
-			while (lexer.Character.ToString() != Token.Eof)
+			List<string> errors = parser.Errors();
+
+			if (errors.Count() != 0)
 			{
-				Token? token = lexer.NextToken();
-				if (token is not null)
-				{
-					writer.WriteLine($"Literal: {token.Literal}, Type: {token.Type}");
-				}
+				PrintParserErrors(writer, errors);
+				continue;
 			}
+
+			writer.WriteLine(ast.String());
+			writer.WriteLine();
+		}
+	}
+
+	private static void PrintParserErrors(TextWriter writer, List<string> errors)
+	{
+		foreach (string error in errors)
+		{
+			writer.WriteLine($"\t{error}");
 		}
 	}
 }


### PR DESCRIPTION
## Added `CallExpression` parsing logic

- Added `CallExpression` class inheriting from `IExpression`
- Added methods for parsing `CallExpressions` and associated arguments
- Updated token precedence map to include `LParen` tokens
- Added `CallExpression` tests

## Updated REPL to utilize `Parser`

- Updated REPL loop to initialize `Parser` and output AST
- Added parser errors to output 