### PR TITLE
Feature: Added Array support

### DIFF
--- a/MonkeyInterpreter.Core/AbstractSyntaxTree/ArrayLiteral.cs
+++ b/MonkeyInterpreter.Core/AbstractSyntaxTree/ArrayLiteral.cs
@@ -1,0 +1,38 @@
+﻿using System.Text;
+using MonkeyInterpreter.Core.Parser;
+
+namespace MonkeyInterpreter.Core.AbstractSyntaxTree;
+
+public class ArrayLiteral : IExpression
+{
+	public readonly Token Token;
+	public List<IExpression>? Elements;
+
+	public ArrayLiteral(Token token, List<IExpression>? elements = null)
+	{
+		Token = token;
+		Elements = elements;
+	}
+
+	public string TokenLiteral()
+	{
+		return Token.Literal;
+	}
+
+	public string String()
+	{
+		StringBuilder stringBuilder = new();
+		List<string> elements = new();
+
+		foreach (var element in Elements)
+		{
+			elements.Add(element.String());
+		}
+
+		stringBuilder.Append("[");
+		stringBuilder.Append(string.Join(", ", elements));
+		stringBuilder.Append("]");
+
+		return stringBuilder.ToString();
+	}
+}

--- a/MonkeyInterpreter.Core/AbstractSyntaxTree/IndexExpression.cs
+++ b/MonkeyInterpreter.Core/AbstractSyntaxTree/IndexExpression.cs
@@ -1,0 +1,36 @@
+﻿using System.Text;
+using MonkeyInterpreter.Core.Parser;
+
+namespace MonkeyInterpreter.Core.AbstractSyntaxTree;
+
+public class IndexExpression : IExpression
+{
+	public readonly Token Token;
+	public IExpression Left;
+	public IExpression Index;
+
+	public IndexExpression(Token token, IExpression left, IExpression index)
+	{
+		Token = token;
+		Left = left;
+		Index = index;
+	}
+
+	public string TokenLiteral()
+	{
+		return Token.Literal;
+	}
+
+	public string String()
+	{
+		StringBuilder stringBuilder = new();
+
+		stringBuilder.Append("(");
+		stringBuilder.Append(Left.String());
+		stringBuilder.Append("[");
+		stringBuilder.Append(Index.String());
+		stringBuilder.Append("])");
+
+		return stringBuilder.ToString();
+	}
+}

--- a/MonkeyInterpreter.Core/Evaluator/ArrayObject.cs
+++ b/MonkeyInterpreter.Core/Evaluator/ArrayObject.cs
@@ -1,0 +1,37 @@
+﻿using System.Text;
+
+namespace MonkeyInterpreter.Core.Evaluator;
+
+public class ArrayObject : IObject
+{
+	private const ObjectTypeEnum ObjectType = ObjectTypeEnum.Array;
+	
+	public List<IObject> Elements;
+
+	public ArrayObject(List<IObject> elements)
+	{
+		Elements = elements;
+	}
+
+	public ObjectTypeEnum Type()
+	{
+		return ObjectType;
+	}
+
+	public string Inspect()
+	{
+		StringBuilder stringBuilder = new StringBuilder();
+
+		List<string> elements = new();
+		foreach (IObject element in Elements)
+		{
+			elements.Add(element.Inspect());
+		}
+
+		stringBuilder.Append("[");
+		stringBuilder.Append(string.Join(", ", elements));
+		stringBuilder.Append("]");
+
+		return stringBuilder.ToString();
+	}
+}

--- a/MonkeyInterpreter.Core/Evaluator/BuiltIns.cs
+++ b/MonkeyInterpreter.Core/Evaluator/BuiltIns.cs
@@ -1,10 +1,16 @@
-﻿namespace MonkeyInterpreter.Core.Evaluator;
+﻿using MonkeyInterpreter.Core.AbstractSyntaxTree;
+
+namespace MonkeyInterpreter.Core.Evaluator;
 
 public static class BuiltIns
 {
 	public static Dictionary<string, BuiltInObject> BuiltInFunctions = new()
 	{
-		{ "len", new BuiltInObject(Len) }
+		{ "len", new BuiltInObject(Len) },
+		{ "first", new BuiltInObject(First) },
+		{ "last", new BuiltInObject(Last) },
+		{ "rest", new BuiltInObject(Rest) },
+		{ "push", new BuiltInObject(Push) },
 	};
 
 	private static IObject Len(params IObject[] args)
@@ -20,9 +26,105 @@ public static class BuiltIns
 			case StringObject stringObject:
 				return new IntegerObject(stringObject.Value.Length);
 			
+			case ArrayObject arrayObject:
+				return new IntegerObject(arrayObject.Elements.Count);
+			
 			default:
 				return Evaluator.GenerateError("Argument to 'len' not supported. Expected String but got {0}",
 					args[0].Type());
 		}
+	}
+
+	private static IObject First(params IObject[] args)
+	{
+		if (args.Length != 1)
+		{
+			return Evaluator.GenerateError("Wrong number of arguments. Got {0}, expected 1",
+				args.Length);
+		}
+
+		if (args[0].Type() != ObjectTypeEnum.Array)
+		{
+			return Evaluator.GenerateError("Argument to 'first' must be Array, got {0}",
+				args[0].Type());
+		}
+
+		ArrayObject array = (ArrayObject)args[0];
+		if (array.Elements.Count > 0)
+		{
+			return array.Elements[0];
+		}
+
+		return new NullObject();
+	}
+	
+	private static IObject Last(params IObject[] args)
+	{
+		if (args.Length != 1)
+		{
+			return Evaluator.GenerateError("Wrong number of arguments. Got {0}, expected 1",
+				args.Length);
+		}
+
+		if (args[0].Type() != ObjectTypeEnum.Array)
+		{
+			return Evaluator.GenerateError("Argument to 'last' must be Array, got {0}",
+				args[0].Type());
+		}
+
+		ArrayObject array = (ArrayObject)args[0];
+		if (array.Elements.Count > 0)
+		{
+			return array.Elements[^1];
+		}
+
+		return new NullObject();
+	}
+	
+	private static IObject Rest(params IObject[] args)
+	{
+		if (args.Length != 1)
+		{
+			return Evaluator.GenerateError("Wrong number of arguments. Got {0}, expected 1",
+				args.Length);
+		}
+
+		if (args[0].Type() != ObjectTypeEnum.Array)
+		{
+			return Evaluator.GenerateError("Argument to 'rest' must be Array, got {0}",
+				args[0].Type());
+		}
+
+		ArrayObject array = (ArrayObject)args[0];
+		if (array.Elements.Count > 0)
+		{
+			List<IObject> elements = array.Elements.GetRange(1, array.Elements.Count - 1);
+			return new ArrayObject(elements);
+		}
+
+		return new NullObject();
+	}
+	
+	private static IObject Push(params IObject[] args)
+	{
+		if (args.Length != 2)
+		{
+			return Evaluator.GenerateError("Wrong number of arguments. Got {0}, expected 1",
+				args.Length);
+		}
+
+		if (args[0].Type() != ObjectTypeEnum.Array)
+		{
+			return Evaluator.GenerateError("Argument to 'push' must be Array, got {0}",
+				args[0].Type());
+		}
+
+		ArrayObject array = (ArrayObject)args[0];
+		
+		List<IObject> elements = array.Elements.GetRange(0, array.Elements.Count);
+		elements.Add(args[1]);
+		
+		return new ArrayObject(elements);
+
 	}
 }

--- a/MonkeyInterpreter.Core/Evaluator/Evaluator.cs
+++ b/MonkeyInterpreter.Core/Evaluator/Evaluator.cs
@@ -115,6 +115,21 @@ public static class Evaluator
 				}
 
 				return new ArrayObject(elements);
+			
+			case IndexExpression indexExpression:
+				IObject left = Evaluate(indexExpression.Left, env);
+				if (left.Type() == ObjectTypeEnum.Error)
+				{
+					return left;
+				}
+
+				IObject index = Evaluate(indexExpression.Index, env);
+				if (index.Type() == ObjectTypeEnum.Error)
+				{
+					return index;
+				}
+
+				return EvaluateIndexExpression(left, index);
 
 			default:
 				return NullObject;
@@ -280,6 +295,32 @@ public static class Evaluator
 				return GenerateError("Unknown operator: {0} {1} {2}",
 					left.Type(), @operator, right.Type());
 		}
+	}
+
+	private static IObject EvaluateIndexExpression(IObject left, IObject index)
+	{
+		switch (true)
+		{
+			case true when left.Type() == ObjectTypeEnum.Array && index.Type() == ObjectTypeEnum.Integer:
+				return EvaluateArrayExpression(left, index);
+			
+			default:
+				return GenerateError("Index operator not supported: {0]", left.Type());
+		}
+	}
+
+	private static IObject EvaluateArrayExpression(IObject left, IObject index)
+	{
+		ArrayObject arrayObject = (ArrayObject)left;
+		int requestedIndex = ((IntegerObject)index).Value;
+		int maxIndex = arrayObject.Elements.Count - 1;
+
+		if (requestedIndex < 0 || requestedIndex > maxIndex)
+		{
+			return NullObject;
+		}
+
+		return arrayObject.Elements[requestedIndex];
 	}
 
 	private static IObject EvaluateBlockStatement(BlockStatement blockStatement, VariableEnvironment env)

--- a/MonkeyInterpreter.Core/Evaluator/Evaluator.cs
+++ b/MonkeyInterpreter.Core/Evaluator/Evaluator.cs
@@ -1,5 +1,4 @@
-﻿using System.Runtime.InteropServices.JavaScript;
-using MonkeyInterpreter.Core.AbstractSyntaxTree;
+﻿using MonkeyInterpreter.Core.AbstractSyntaxTree;
 
 namespace MonkeyInterpreter.Core.Evaluator;
 
@@ -108,6 +107,15 @@ public static class Evaluator
 					false => FalseBooleanObject
 				};
 			
+			case ArrayLiteral arrayLiteral:
+				List<IObject> elements = EvaluateExpressions(arrayLiteral.Elements, env);
+				if (elements.Count == 1 && elements[0].Type() == ObjectTypeEnum.Error)
+				{
+					return elements[0];
+				}
+
+				return new ArrayObject(elements);
+
 			default:
 				return NullObject;
 		}

--- a/MonkeyInterpreter.Core/Evaluator/ObjectTypeEnum.cs
+++ b/MonkeyInterpreter.Core/Evaluator/ObjectTypeEnum.cs
@@ -6,8 +6,9 @@ public enum ObjectTypeEnum
 	Integer,
 	String,
 	Boolean,
+	Array,
 	ReturnValue,
 	Function,
 	BuiltIn,
-	Error
+	Error,
 }

--- a/MonkeyInterpreter.Core/Parser/Lexer.cs
+++ b/MonkeyInterpreter.Core/Parser/Lexer.cs
@@ -97,6 +97,14 @@ public class Lexer
 				token = new Token(Token.RBrace, Character.ToString());
 				break;
 			
+			case '[':
+				token = new Token(Token.LBracket, Character.ToString());
+				break;
+			
+			case ']':
+				token = new Token(Token.RBracket, Character.ToString());
+				break;
+			
 			case '\0':
 				token = new Token(Token.Eof, '\0'.ToString());
 				break;
@@ -178,7 +186,7 @@ public class Lexer
 
 	private bool IsLetter(char character)
 	{
-		return character is >= 'a' or >= 'A' and >= 'Z';
+		return ('a' <= character && character <= 'z') || ('A' <= character && character <= 'Z' || character == '_');
 	}
 
 	private void SkipWhitespace()

--- a/MonkeyInterpreter.Core/Parser/Token.cs
+++ b/MonkeyInterpreter.Core/Parser/Token.cs
@@ -32,6 +32,8 @@ public class Token(string type, string literal)
 	public const string RParen = ")";
 	public const string LBrace = "{";
 	public const string RBrace = "}";
+	public const string LBracket = "[";
+	public const string RBracket = "]";
 
 	// Keywords
 	public const string Function = "FUNCTION";

--- a/MonkeyInterpreter.Tests/Evaluator/EvaluatorTests.cs
+++ b/MonkeyInterpreter.Tests/Evaluator/EvaluatorTests.cs
@@ -322,6 +322,52 @@ public class ArrayLiteralTests
 		}
 		
 		Assert.Equal(expectedElementValues, actualValues);
+	}
+}
+
+public class IndexExpressionTests
+{
+	[Theory]
+	[InlineData("[1,2,3][0]", 1)]
+	[InlineData("[1,2,3][1]", 2)]
+	[InlineData("[1,2,3][2]", 3)]
+	[InlineData("[1,2,3][3]", null)]
+	[InlineData( "let i = 0; [1][i];", 1)]
+	[InlineData("[1,2,3][1 + 1]", 3)]
+	[InlineData( "let myArray= [1,2,3]; myArray[1];", 2)]
+	[InlineData( "let myArray = [1, 2, 3]; myArray[0] + myArray[1] + myArray[2];", 6)]
+	[InlineData(  "let myArray = [1, 2, 3]; let i = myArray[0]; myArray[i]", 2)]
+	[InlineData(  "[1, 2, 3][-1]", null)]
+	[InlineData(  "[\"test\", true][0]", "test")]
+	[InlineData(  "[\"test\", true][1]", true)]
+	public void IndexExpression_ReturnsExpectedValue(string expression, object expectedValue)
+	{
+		Program program = new(expression);
+		VariableEnvironment env = new();
+		IObject resultObject = Core.Evaluator.Evaluator.Evaluate(program.Ast, env);
+
+		object? value;
+
+		switch (resultObject)
+		{
+			case IntegerObject integerObject:
+				value = integerObject.Value;
+				break;
+			
+			case StringObject stringObject:
+				value = stringObject.Value;
+				break;
+			
+			case BooleanObject booleanObject:
+				value = booleanObject.Value;
+				break;
+			
+			default:
+				value = null;
+				break;
+		}
+		
+		Assert.Equal(expectedValue, value);
 
 	}
 }

--- a/MonkeyInterpreter.Tests/Evaluator/EvaluatorTests.cs
+++ b/MonkeyInterpreter.Tests/Evaluator/EvaluatorTests.cs
@@ -1,5 +1,4 @@
-﻿using MonkeyInterpreter.Core;
-using MonkeyInterpreter.Core.AbstractSyntaxTree;
+﻿using MonkeyInterpreter.Core.AbstractSyntaxTree;
 using MonkeyInterpreter.Core.Evaluator;
 
 namespace MonkeyInterpreter.Tests.Evaluator;
@@ -271,5 +270,58 @@ public class BuiltInFunctionTests
 		};
 		
 		Assert.Equal(expectedValue, actualValue);
+	}
+}
+
+public class ArrayLiteralTests
+{
+	[Theory]
+	[InlineData("[0]", 1)]
+	[InlineData("[1, 2 * 2, 3 + 3]", 3)]
+	public void ArrayObject_HasExpectedElementCount(string expression, int expectedElementCount)
+	{
+		Program program = new(expression);
+		VariableEnvironment env = new();
+		ArrayObject arrayLiteral = (ArrayObject)Core.Evaluator.Evaluator.Evaluate(program.Ast, env);
+		
+		Assert.Equal(expectedElementCount, arrayLiteral.Elements.Count);
+
+	}
+	
+	[Theory]
+	[InlineData("[0]" , new object[] { 0 })]
+	[InlineData("[1, 2 * 2, 3 + 3]", new object[] { 1, 4, 6})]
+	public void ArrayObject_ElementsEvaluateAsExpected(string expression, object[] expectedElementValues)
+	{
+		Program program = new(expression);
+		VariableEnvironment env = new();
+		ArrayObject arrayLiteral = (ArrayObject)Core.Evaluator.Evaluator.Evaluate(program.Ast, env);
+
+		List<object> actualValues = new();
+
+		for (int i = 0; i < arrayLiteral.Elements.Count; i++)
+		{
+			switch (arrayLiteral.Elements[i])
+			{
+				case IntegerObject integerObject:
+					actualValues.Add(integerObject.Value);
+					break;
+				
+				case StringObject stringObject:
+					actualValues.Add(stringObject.Value);
+					break;
+				
+				case BooleanObject booleanObject:
+					actualValues.Add(booleanObject.Value);
+					break;
+				
+				default:
+					Assert.Fail("Invalid Element object type");
+					break;
+			}
+		}
+		
+		Assert.Equal(expectedElementValues, actualValues);
+
 	}
 }

--- a/MonkeyInterpreter.Tests/Lexer/LexerTest.cs
+++ b/MonkeyInterpreter.Tests/Lexer/LexerTest.cs
@@ -1,12 +1,9 @@
-using System.Runtime.InteropServices;
 using MonkeyInterpreter.Core.Parser;
 using Xunit.Abstractions;
 
 namespace MonkeyInterpreter.Tests.Lexer;
 
-using System.Collections.Generic;
-
-using Core;
+// TODO: Rework test to follow standardized structure - see Parser or Evaluator tests
 
 public class LexerTest
 {
@@ -42,6 +39,8 @@ public class LexerTest
 		            		10 != 9;
 		            		"foobar";
 		            		"foo bar";
+		            		
+		            		[1,2];
 		            """;
 		var tests = new List<List<string>>()
 		{
@@ -121,6 +120,12 @@ public class LexerTest
 			new() { Token.String, "foobar" },
 			new() { Token.Semicolon, ";" },
 			new() { Token.String, "foo bar" },
+			new() { Token.Semicolon, ";" },
+			new() { Token.LBracket, "[" },
+			new() { Token.Int, "1" },
+			new() { Token.Comma, "," },
+			new() { Token.Int, "2" },
+			new() { Token.RBracket, "]" },
 			new() { Token.Semicolon, ";" },
 			new() { Token.Eof, "" },
 		};


### PR DESCRIPTION
## Added `ArrayLiteral` and `IndexExpression` parsing and evaluation

- Added left and right bracket `Token` types
- Added `Lexer` logic for handling new tokens
- Created `ArrayLiteral` and `IndexExpression` classes
- Added `Parser` methods for parsing classes
- Added `ArrayObject` class
- Added `Evaluator` logic for `ArrayLiteral` and `IndexExpression`
- Added `Lexer`, `Parser` and `Evaluator` tests

## Updated `BuiltIns`

- Extended `len` function to return lengths of arrays
- Added new, array specific built-ins
  - `first` - value at first index of array
  - `last` - value at last index of array
  - `rest` - generates new array with all elements of another array after the first
  - `push` - generates new array with all elements of another plus the specified new element

## Resolved `Lexer.IsLetter` bug

`IsLetter` method was causing identifier parsing issues when followed by a right bracket. Method was set to allow all character codes greater than or equal to 'a' (97) OR greater than or equal to 'A' (65) AND greater than or equal to 'Z' (90). ']', being 93, fulfilled the later evaluation and was considered part of the identifier.

New method correctly applies character ranges and includes '_' (95) as a valid character for identifiers.